### PR TITLE
Include z/Z to the char set

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,10 +51,10 @@ func run(w io.Writer, o, n, nc, sc int) error {
 
 	var buf bytes.Buffer
 	if n > nnc+nsc {
-		for r := 'a'; r < 'z'; r++ {
+		for r := 'a'; r <= 'z'; r++ {
 			buf.WriteRune(r)
 		}
-		for r := 'A'; r < 'Z'; r++ {
+		for r := 'A'; r <= 'Z'; r++ {
 			buf.WriteRune(r)
 		}
 	}


### PR DESCRIPTION
I noticed that 'z' and 'Z' are not included in the `buf`, meaning they won't be part of the generated password. While this will not significantly impact the strength of the password generation, it would be better to include them unless there's a specific reason not to.